### PR TITLE
Unify glossary terms for cleanup command

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -92,7 +92,7 @@ class Program
         Console.WriteLine();
         Console.WriteLine("Commands:");
         Console.WriteLine("  translate   Translate resource files");
-        Console.WriteLine("  cleanup     Remove entries not present in example file");
+        Console.WriteLine("  cleanup     Remove entries not present in source file");
         Console.WriteLine();
         Console.WriteLine("translate options:");
         Console.WriteLine("  --all             translate all items");
@@ -102,8 +102,8 @@ class Program
         Console.WriteLine("  --language <lang> target language");
         Console.WriteLine();
         Console.WriteLine("cleanup options:");
-        Console.WriteLine("  --example <file>  example resx file");
-        Console.WriteLine("  --files <files>   resx files to clean separated by space");
+        Console.WriteLine("  --source <file>   source resx file");
+        Console.WriteLine("  --target <files>  resx files to clean separated by space");
     }
 
     private static async Task RunTranslate(string[] args, IConfiguration configuration)
@@ -126,12 +126,12 @@ class Program
 
     private static void RunCleanup(string[] args)
     {
-        string? exampleFile = GetOption(args, "--example");
-        var files = GetOptions(args, "--files");
+        string? sourceFile = GetOption(args, "--source");
+        var targetFiles = GetOptions(args, "--target");
 
-        Console.WriteLine($"Example file: {exampleFile}");
-        Console.WriteLine("Files to clean:");
-        foreach (var f in files)
+        Console.WriteLine($"Source file: {sourceFile}");
+        Console.WriteLine("Target files:");
+        foreach (var f in targetFiles)
         {
             Console.WriteLine($" - {f}");
         }

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ Run the program with .NET CLI
 
 ```
 TranslateResx translate [--all|--missing] [--source <resx>] [--target <resx>] [--language <lang>]
-TranslateResx cleanup --example <resx> --files <file1> [<file2> ...]
+TranslateResx cleanup --source <resx> --target <file1> [<file2> ...]
 ```
 
 - `--all` translates every item in the target file.
 - `--missing` translates only the items missing from the target file.
 - `--source` allows you to specify which `Strings.resx` to use as the source of truth.
 - `--language` sets the language to translate into.
-- `cleanup` compares selected `.resx` files with the example one and removes items not found in the example.
+- `cleanup` compares target `.resx` files with the source one and removes items not found in the source.
 
 The actual processing for these options is not yet implemented.
 


### PR DESCRIPTION
## Summary
- rename cleanup `--example` option to `--source`
- rename cleanup `--files` option to `--target`
- update help text and README accordingly

## Testing
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686a87907cf4832d8d26256c864f7b57