### PR TITLE
Set interactive defaults for language and path

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -138,6 +138,7 @@ class Program
     private static async Task RunTranslateInteractive(IConfiguration configuration)
     {
         string defaultResourcesPath = configuration["Files:ResourcesPath"] ?? string.Empty;
+        string defaultSourceLanguage = "en-US";
         string? subscriptionKey = configuration["AzureTranslation:SubscriptionKey"];
 
         // Ask the user for the folder that contains the Strings.<culture>.resx files.
@@ -147,8 +148,10 @@ class Program
             resourcesDir = defaultResourcesPath;
 
         // The UI now builds file names based on the languages the user enters.
-        Console.Write("Source language code (e.g. en-US): ");
+        Console.Write($"Source language code [{defaultSourceLanguage}]: ");
         string? sourceLanguage = Console.ReadLine();
+        if (string.IsNullOrWhiteSpace(sourceLanguage))
+            sourceLanguage = defaultSourceLanguage;
 
         Console.Write("Target language codes (space separated): ");
         string? targetLanguagesInput = Console.ReadLine();
@@ -156,7 +159,6 @@ class Program
             .Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
         if (string.IsNullOrWhiteSpace(resourcesDir) ||
-            string.IsNullOrWhiteSpace(sourceLanguage) ||
             targetLanguages.Length == 0)
         {
             Console.WriteLine("Resource directory and languages are required.");

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Only a few values are required:
 
 `SupportedCultures` defines which languages appear in the menu while `ExampleLanguages` provides quick suggestions. `ResourcesPath` should point to the directory that contains all your `.resx` files. Language codes are mapped to display names in `LanguageData.cs` so that the UI can show user-friendly names while the configuration continues to use codes.
 
-When you run the application with no command line arguments a simple menu is displayed. Choose **Translate resource file** and you will be prompted for the resources directory, the source language and one or more target languages. The tool automatically builds file names like `Strings.en.resx` or `Strings.fr.resx` based on your input.
+When you run the application with no command line arguments a simple menu is displayed. Choose **Translate resource file** and you will be prompted for the resources directory, the source language and one or more target languages. If you press Enter without typing a directory, the value from `appsettings.json` is used. Leaving the source language blank defaults to `en-US`. The tool automatically builds file names like `Strings.en.resx` or `Strings.fr.resx` based on your input.
 
 Run the program with .NET CLI
 
@@ -69,7 +69,7 @@ TranslateResx cleanup --source <resx> --target <file1> [<file2> ...]
 ### Example
 
 Run the tool without arguments and select **Translate resource file** from the menu.
-Enter the resources directory, choose a source language (e.g. `en`) and provide one or more target languages separated by spaces. For instance entering `de fr` will create `Strings.de.resx` and `Strings.fr.resx` next to your source file.
+When prompted you can press Enter to use the resources directory from `appsettings.json` and leave the source language blank to use `en-US`. Then enter one or more target languages separated by spaces. For instance entering `de fr` will create `Strings.de.resx` and `Strings.fr.resx` next to your source file.
 
 
 Contributing


### PR DESCRIPTION
## Summary
- default the resources directory to value from `appsettings.json` when the user hits Enter
- default source language to `en-US`
- document new default behaviour in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686acf10c3fc832d8d05981bb79639dc