### PR TITLE
Improve language code handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Only a few values are required:
 
 `SupportedCultures` defines which languages appear in the menu while `ExampleLanguages` provides quick suggestions. `ResourcesPath` should point to the directory that contains all your `.resx` files. Language codes are mapped to display names in `LanguageData.cs` so that the UI can show user-friendly names while the configuration continues to use codes.
 
-When you run the application with no command line arguments a simple menu is displayed. Choose **Translate resource file** and you will be prompted for the resources directory, the source language and one or more target languages. If you press Enter without typing a directory, the value from `appsettings.json` is used. Leaving the source language blank defaults to `en-US`. The tool automatically builds file names like `Strings.en.resx` or `Strings.fr.resx` based on your input.
+When you run the application with no command line arguments a simple menu is displayed. Choose **Translate resource file** and you will be prompted for the resources directory, the source language and one or more target languages. If you press Enter without typing a directory, the value from `appsettings.json` is used. Leaving the source language blank defaults to `en`. The tool automatically builds file names like `Strings.en.resx` or `Strings.fr.resx` based on your input. Both two letter codes and full culture names are supported when locating files.
 
 When the tool starts it prints a table of all configured cultures.
 The table shows each language code, its friendly name and information
@@ -74,7 +74,7 @@ TranslateResx cleanup --source <resx> --target <file1> [<file2> ...]
 ### Example
 
 Run the tool without arguments and select **Translate resource file** from the menu.
-When prompted you can press Enter to use the resources directory from `appsettings.json` and leave the source language blank to use `en-US`. Then enter one or more target languages separated by spaces. For instance entering `de fr` will create `Strings.de.resx` and `Strings.fr.resx` next to your source file.
+When prompted you can press Enter to use the resources directory from `appsettings.json` and leave the source language blank to use `en`. Then enter one or more target languages separated by spaces. For instance entering `de fr` will create `Strings.de.resx` and `Strings.fr.resx` next to your source file.
 
 
 Contributing


### PR DESCRIPTION
## Summary
- handle resource files that use short two-letter codes or full culture codes
- set default source language to `en`
- mention the new behavior in the docs

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686adb40654c832d93fdf1a76f7c6a24