### PR TITLE
Improve fallback behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ Only a few values are required:
 
 `SupportedCultures` defines which languages appear in the menu while `ExampleLanguages` provides quick suggestions. `ResourcesPath` should point to the directory that contains all your `.resx` files. Language codes are mapped to display names in `LanguageData.cs` so that the UI can show user-friendly names while the configuration continues to use codes.
 
-When you run the application with no command line arguments a simple menu is displayed. Choose **Translate resource file** and you will be prompted for the resources directory, the source language and one or more target languages. If you press Enter without typing a directory, the value from `appsettings.json` is used. Leaving the source language blank defaults to `en`. The tool automatically builds file names like `Strings.en.resx` or `Strings.fr.resx` based on your input. Both two letter codes and full culture names are supported when locating files.
+When you run the application with no command line arguments a simple menu is displayed. Choose **Translate resource file** and the tool will use the resources directory configured in `appsettings.json`. The selected path is printed so you know which folder is being used. You are prompted only for the source language and one or more target languages. Leaving the source language blank defaults to `en`. The tool automatically builds file names like `Strings.en.resx` or `Strings.fr.resx` based on your input. Both two letter codes and full culture names are supported when locating files. If a resource file for `en` or `en-US` is missing the program will use `Strings.resx`; for all other languages the file must exist or an error is shown.
 
-When the tool starts it prints a table of all configured cultures.
-The table shows each language code, its friendly name and information
-about any existing resource file found in `ResourcesPath`, including
-file size and the last modification date.
+Whenever the menu is displayed the program prints a table of all
+configured cultures. The table shows each language code, its friendly
+name and information about any existing resource file found in
+`ResourcesPath`, including file size and the last modification date.
 
 Run the program with .NET CLI
 


### PR DESCRIPTION
## Summary
- support fallback to Strings.resx only when the language is English
- apply fallback for target languages as well
- document new rule in README
- show table of languages each time the menu is displayed

## Testing
- `dotnet build -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae69ec17c832da742d79839764db3