### PR TITLE
Introduce quality checker and refactor

### DIFF
--- a/ResxTranslator.cs
+++ b/ResxTranslator.cs
@@ -1,0 +1,102 @@
+using Azure.AI.Translation.Text;
+using Azure;
+using HtmlAgilityPack;
+using System.Xml.Linq;
+
+/// <summary>
+/// Provides functionality to translate entire .resx files using Azure Translator.
+/// </summary>
+public static class ResxTranslator
+{
+    /// <summary>
+    /// Translates the values of a .resx file and writes them to the target file.
+    /// </summary>
+    public static async Task TranslateFileAsync(string subscriptionKey, string sourceFilePath, string targetFilePath, string targetLanguage)
+    {
+        if (string.IsNullOrWhiteSpace(subscriptionKey) ||
+            string.IsNullOrWhiteSpace(sourceFilePath) ||
+            string.IsNullOrWhiteSpace(targetFilePath) ||
+            string.IsNullOrWhiteSpace(targetLanguage))
+        {
+            Console.WriteLine("One or more required configuration values are missing.");
+            return;
+        }
+
+        AzureKeyCredential credential = new(subscriptionKey);
+        TextTranslationClient translationService;
+        try
+        {
+            translationService = new TextTranslationClient(credential);
+        }
+        catch (Exception ex) when (ex is UriFormatException || ex is ArgumentException)
+        {
+            Console.WriteLine(ex is UriFormatException ? "The endpoint URL is not valid." : "The subscription key is not valid.");
+            return;
+        }
+
+        if (!File.Exists(sourceFilePath))
+        {
+            Console.WriteLine($"Source file not found: {sourceFilePath}");
+            return;
+        }
+
+        XDocument sourceDoc;
+        try
+        {
+            sourceDoc = XDocument.Load(sourceFilePath);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Failed to load the source file as an XML document: {ex.Message}");
+            return;
+        }
+
+        var dataElements = sourceDoc.Descendants("data").Where(x => x.Element("value") != null);
+        if (!dataElements.Any())
+        {
+            Console.WriteLine("The source file does not contain any translatable elements.");
+            return;
+        }
+
+        int total = dataElements.Count();
+        int current = 0;
+
+        foreach (var dataElement in dataElements)
+        {
+            current++;
+            string sourceText = dataElement.Element("value")?.Value ?? string.Empty;
+            if (string.IsNullOrEmpty(sourceText))
+                continue;
+
+            try
+            {
+                HtmlDocument doc = new HtmlDocument();
+                doc.LoadHtml(sourceText);
+
+                foreach (var textNode in doc.DocumentNode.DescendantsAndSelf().Where(n => n.NodeType == HtmlNodeType.Text))
+                {
+                    string nodeText = textNode.InnerHtml;
+                    var response = await translationService.TranslateAsync(targetLanguage, nodeText);
+                    var result = response.Value.FirstOrDefault();
+                    string translatedText = result?.Translations.FirstOrDefault()?.Text;
+                    if (translatedText != null)
+                    {
+                        textNode.InnerHtml = translatedText;
+                    }
+                }
+
+                string translatedHtml = doc.DocumentNode.OuterHtml;
+                dataElement.Element("value")!.Value = translatedHtml;
+                Program.ShowProgress(current, total);
+            }
+            catch (RequestFailedException ex)
+            {
+                Console.WriteLine($"Translation failed. Error code: {ex.ErrorCode}, Message: {ex.Message}");
+                return;
+            }
+        }
+
+        sourceDoc.Save(targetFilePath);
+        Console.WriteLine();
+    }
+}

--- a/TranslationQualityChecker.cs
+++ b/TranslationQualityChecker.cs
@@ -1,0 +1,102 @@
+using Azure.AI.Translation.Text;
+using Azure;
+using System.Xml.Linq;
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>
+/// Provides functionality to evaluate translation quality using a round-trip translation.
+/// </summary>
+public static class TranslationQualityChecker
+{
+    /// <summary>
+    /// Performs a back-translation check for each entry and returns a list of confidence scores.
+    /// </summary>
+    public static async Task<List<(string Key, int Rating)>> CheckQualityAsync(string subscriptionKey, string sourceFilePath, string targetFilePath, string sourceLanguage, string targetLanguage)
+    {
+        var results = new List<(string Key, int Rating)>();
+
+        if (string.IsNullOrWhiteSpace(subscriptionKey) ||
+            string.IsNullOrWhiteSpace(sourceFilePath) ||
+            string.IsNullOrWhiteSpace(targetFilePath))
+        {
+            Console.WriteLine("Missing configuration values for quality check.");
+            return results;
+        }
+
+        if (!File.Exists(sourceFilePath) || !File.Exists(targetFilePath))
+        {
+            Console.WriteLine("Source or target file not found for quality check.");
+            return results;
+        }
+
+        XDocument sourceDoc = XDocument.Load(sourceFilePath);
+        XDocument targetDoc = XDocument.Load(targetFilePath);
+        var sourceData = sourceDoc.Descendants("data").Where(x => x.Element("value") != null);
+        var targetLookup = targetDoc.Descendants("data").Where(x => x.Element("value") != null).ToDictionary(e => e.Attribute("name")?.Value ?? string.Empty);
+
+        AzureKeyCredential credential = new(subscriptionKey);
+        TextTranslationClient client = new TextTranslationClient(credential);
+
+        foreach (var data in sourceData)
+        {
+            string key = data.Attribute("name")?.Value ?? string.Empty;
+            if (!targetLookup.TryGetValue(key, out var targetElement))
+                continue;
+
+            string originalText = data.Element("value")?.Value ?? string.Empty;
+            string translatedText = targetElement.Element("value")?.Value ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(translatedText))
+                continue;
+
+            var response = await client.TranslateAsync(sourceLanguage, translatedText, targetLanguage);
+            var result = response.Value.FirstOrDefault();
+            string backTranslated = result?.Translations.FirstOrDefault()?.Text ?? string.Empty;
+
+            double score = Similarity(originalText, backTranslated);
+            int rating = ScoreToRating(score);
+            results.Add((key, rating));
+        }
+
+        return results;
+    }
+
+    private static double Similarity(string s1, string s2)
+    {
+        if (string.IsNullOrEmpty(s1) && string.IsNullOrEmpty(s2))
+            return 1.0;
+        int distance = LevenshteinDistance(s1, s2);
+        int maxLen = Math.Max(s1.Length, s2.Length);
+        if (maxLen == 0) return 1.0;
+        return 1.0 - ((double)distance / maxLen);
+    }
+
+    private static int LevenshteinDistance(string s, string t)
+    {
+        int n = s.Length;
+        int m = t.Length;
+        int[,] d = new int[n + 1, m + 1];
+        for (int i = 0; i <= n; i++) d[i, 0] = i;
+        for (int j = 0; j <= m; j++) d[0, j] = j;
+        for (int i = 1; i <= n; i++)
+        {
+            for (int j = 1; j <= m; j++)
+            {
+                int cost = s[i - 1] == t[j - 1] ? 0 : 1;
+                d[i, j] = Math.Min(
+                    Math.Min(d[i - 1, j] + 1, d[i, j - 1] + 1),
+                    d[i - 1, j - 1] + cost);
+            }
+        }
+        return d[n, m];
+    }
+
+    private static int ScoreToRating(double score)
+    {
+        if (score >= 0.90) return 5;
+        if (score >= 0.75) return 4;
+        if (score >= 0.50) return 3;
+        if (score >= 0.25) return 2;
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary
- move translation code into `ResxTranslator`
- add `TranslationQualityChecker` to compute confidence scores via round‑trip translation
- expose new menu option for quality checking

## Testing
- `dotnet restore`
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686b73bddb0c832d86f83d64c90d7daa