### PR TITLE
Fix parsing of multiple language codes

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -136,10 +136,14 @@ class Program
         if (string.IsNullOrWhiteSpace(sourceLanguage))
             sourceLanguage = defaultSourceLanguage;
 
-        Console.Write("Target language codes (space separated): ");
+        Console.Write("Target language codes (separate with spaces or commas): ");
         string? targetLanguagesInput = Console.ReadLine();
         var targetLanguages = (targetLanguagesInput ?? string.Empty)
-            .Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .SelectMany(part => part.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            .Select(lang => lang.Trim())
+            .Where(lang => !string.IsNullOrWhiteSpace(lang))
+            .ToArray();
 
         if (string.IsNullOrWhiteSpace(resourcesDir) ||
             targetLanguages.Length == 0)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ TranslateResx cleanup --source <resx> --target <file1> [<file2> ...]
 ### Example
 
 Run the tool without arguments and select **Translate resource file** from the menu.
-When prompted you can press Enter to use the resources directory from `appsettings.json` and leave the source language blank to use `en`. Then enter one or more target languages separated by spaces. For instance entering `de fr` will create `Strings.de.resx` and `Strings.fr.resx` next to your source file.
+When prompted you can press Enter to use the resources directory from `appsettings.json` and leave the source language blank to use `en`. Then enter one or more target languages separated by commas and/or spaces. For instance entering `de, fr` or `de fr` will create `Strings.de.resx` and `Strings.fr.resx` next to your source file.
 
 
 Contributing


### PR DESCRIPTION
## Summary
- allow comma or space separated target languages when translating
- clarify README example about using commas and spaces

## Testing
- `dotnet restore` *(fails: current SDK does not support net9.0)*
- `dotnet build -c Release` *(fails: current SDK does not support net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_686d7a945590832d95b638b0e2192d60